### PR TITLE
add PORT=80 to work with Deis readiness probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ $ deis create guestbook
 
 3) Set env vars so the App knows where to connect to redis cluster:
 ```
-$ deis config:set GET_HOSTS_FROM=env REDIS_MASTER_SERVICE_HOST=redis-master.default REDIS_SLAVE_SERVICE_HOST=redis-slave.default -a guestbook
+$ deis config:set GET_HOSTS_FROM=env REDIS_MASTER_SERVICE_HOST=redis-master.default REDIS_SLAVE_SERVICE_HOST=redis-slave.default PORT=80 -a guestbook
 ```
 
 4) Push to remote git repo:


### PR DESCRIPTION
In the deis workflow v2.3.0, it seems readiness probe uses port 443 for health check by default. 

it results in the following error in the k8s log. 
"Readiness probe failed: dial tcp 10.44.0.15:443: getsockopt: connection refused". 
On the web page, it will throw HTTP Error 503 - Service unavailable. 
Passing "PORT=80" as environment variable can fix it. 
